### PR TITLE
Update Registry link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ What things you need to install the software and how to install them
 
 ```
 - Nodejs and npm>=6.1.11
-- Lerna 
+- Lerna
 - Typescript
 ```
 
 ### Installing
 
 - Installs lerna (used for package bundling) and typescript, as well as all build dependencies.
-  
+
 ```
 npm install lerna typescript
 npm install
@@ -54,7 +54,7 @@ npm run build
 npm run test
 ```
 
-- Running build and test 
+- Running build and test
 
 ```
 npm run run_test
@@ -101,7 +101,7 @@ await myZapProvider.initiateProviderCurve({
 ### See more Usages of each packages :
 * [Provider](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Provider/README.md)
 * [Subscriber](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Subscriber/README.md)
-* [Register](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Register/README.md)
+* [Registry](https://github.com/zapproject/zap-monorepo/blob/master/packages/Registry/README.md)
 * [Bondage](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Bondage/README.md)
 * [Dispatch](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Dispatch/README.md)
 * [Arbiter](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Arbiter/README.md)
@@ -112,8 +112,8 @@ await myZapProvider.initiateProviderCurve({
 ## Built With
 
 * [Lerna](https://lernajs.io/) - The tool to manage monorepo project
-* [Typescript](https://www.typescriptlang.org/) 
-* [Mocha](https://mochajs.org/) 
+* [Typescript](https://www.typescriptlang.org/)
+* [Mocha](https://mochajs.org/)
 * [Truffle](https://truffleframework.com/)
 * [Ganache](https://truffleframework.com/ganache)
 
@@ -127,5 +127,3 @@ See also the list of [contributors](https://github.com/zapproject/Zap-monorepo/g
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details
-
-

--- a/packages/Arbiter/README.md
+++ b/packages/Arbiter/README.md
@@ -16,11 +16,11 @@ npm install --save `@zapjs/arbiter`
 ```
 import {ZapArbiter} from '@zapjs/arbiter';
 
-let myZapArbiter = new ZapArbiter(); 
+let myZapArbiter = new ZapArbiter();
 ```
 
 Custom configuration
-``` 
+```
 let myZapArbiter = new ZapArbiter({artifactDir,networkId,networkProvider})
 ```
 Listen to new subscription events
@@ -43,7 +43,7 @@ myZapArbiter.listen(callback)
 ### See more Usages of each packages :
 * [Provider](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Provider/README.md)
 * [Subscriber](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Subscriber/README.md)
-* [Register](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Register/README.md)
+* [Registry](https://github.com/zapproject/zap-monorepo/blob/master/packages/Registry/README.md)
 * [Bondage](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Bondage/README.md)
 * [Dispatch](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Dispatch/README.md)
 * [ZapToken](https://github.com/zapproject/Zap-monorepo/tree/master/packages/ZapToken/README.md)
@@ -53,8 +53,7 @@ myZapArbiter.listen(callback)
 ## Built With
 
 * [Lerna](https://lernajs.io/) - The tool to manage monorepo project
-* [Typescript](https://www.typescriptlang.org/) 
-* [Mocha](https://mochajs.org/) 
+* [Typescript](https://www.typescriptlang.org/)
+* [Mocha](https://mochajs.org/)
 * [Truffle](https://truffleframework.com/)
 * [Ganache](https://truffleframework.com/ganache)
-

--- a/packages/Artifacts/README.md
+++ b/packages/Artifacts/README.md
@@ -31,7 +31,7 @@ Available Artifacts:
 ### See more Usages of each packages :
 * [Provider](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Provider/README.md)
 * [Subscriber](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Subscriber/README.md)
-* [Register](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Register/README.md)
+* [Registry](https://github.com/zapproject/zap-monorepo/blob/master/packages/Registry/README.md)
 * [Bondage](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Bondage/README.md)
 * [Dispatch](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Dispatch/README.md)
 * [ZapToken](https://github.com/zapproject/Zap-monorepo/tree/master/packages/ZapToken/README.md)

--- a/packages/Bondage/README.md
+++ b/packages/Bondage/README.md
@@ -16,11 +16,11 @@ npm install --save `@zapjs/bondage`
 ```
 import {ZapBondage} from '@zapjs/bondage';
 
-let myZapBondage = new ZapBondage(); 
+let myZapBondage = new ZapBondage();
 ```
 
 Custom configuration
-``` 
+```
 let myZapBondage = new ZapBondage({artifactDir,networkId,networkProvider})
 ```
 #### Methods
@@ -47,10 +47,10 @@ Listen to all events
 myZapBondate.listen(callback);
 ```
 
-### See more Usages of each packages 
+### See more Usages of each packages
 * [Provider](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Provider/README.md)
 * [Subscriber](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Subscriber/README.md)
-* [Register](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Register/README.md)
+* [Registry](https://github.com/zapproject/zap-monorepo/blob/master/packages/Registry/README.md)
 * [Dispatch](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Dispatch/README.md)
 * [Arbiter](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Arbiter/README.md)
 * [ZapToken](https://github.com/zapproject/Zap-monorepo/tree/master/packages/ZapToken/README.md)

--- a/packages/Curve/README.md
+++ b/packages/Curve/README.md
@@ -12,7 +12,7 @@ What things you need to install the software and how to install them
 
 ```
 - Nodejs and npm>=6.1.11
-- Lerna 
+- Lerna
 - Typescript
 ```
 
@@ -55,7 +55,7 @@ npm run build
 npm run test
 ```
 
-- Running build and test 
+- Running build and test
 
 ```
 npm run run_test
@@ -108,10 +108,10 @@ await myZapProvider.initiateProviderCurve({
 ```
 
 
-### See more Usages of each packages 
+### See more Usages of each packages
 * [Provider](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Provider/README.md)
 * [Subscriber](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Subscriber/README.md)
-* [Register](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Register/README.md)
+* [Registry](https://github.com/zapproject/zap-monorepo/blob/master/packages/Registry/README.md)
 * [Dispatch](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Dispatch/README.md)
 * [Arbiter](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Arbiter/README.md)
 * [ZapToken](https://github.com/zapproject/Zap-monorepo/tree/master/packages/ZapToken/README.md)
@@ -129,5 +129,3 @@ See also the list of [contributors](https://github.com/zapproject/Zap-monorepo/g
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details
-
-

--- a/packages/Dispatch/README.md
+++ b/packages/Dispatch/README.md
@@ -5,7 +5,7 @@ This repository provides an interface to the Zap Dispatch contract, enabling que
 ### Prerequisites
 
 ```
-- Nodejs and npm>=6.1.11 
+- Nodejs and npm>=6.1.11
 - Typescript
 ```
 
@@ -17,7 +17,7 @@ npm install `@zapjs/dispatch`
 ```
 ```
 import {ZapDispatch} from '@zapjs/dispatch';
-let myZapArbiter = new ZapArbiter(); 
+let myZapArbiter = new ZapArbiter();
 ```
 Custom configuration
 ```
@@ -39,16 +39,15 @@ Listen to Offchain response from provider:
 
 Listen to all events
 ```
-myZapDispatch.listen(callback) 
+myZapDispatch.listen(callback)
 ```
 
 
-### See more Usages of each packages 
+### See more Usages of each packages
 * [Provider](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Provider/README.md)
 * [Subscriber](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Subscriber/README.md)
-* [Register](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Register/README.md)
+* [Registry](https://github.com/zapproject/zap-monorepo/blob/master/packages/Registry/README.md)
 * [Dispatch](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Dispatch/README.md)
 * [Arbiter](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Arbiter/README.md)
 * [ZapToken](https://github.com/zapproject/Zap-monorepo/tree/master/packages/ZapToken/README.md)
 * [Zapjs](https://github.com/zapproject/Zap-monorepo/tree/master/packages/ZapJs/README.md)
-

--- a/packages/Provider/README.md
+++ b/packages/Provider/README.md
@@ -1,6 +1,6 @@
 # @zapjs/provider
 
-This package provides wrapper classes to onchain and offchains oracles on the Zap platform. 
+This package provides wrapper classes to onchain and offchains oracles on the Zap platform.
 
 ### Prerequisites
 
@@ -80,11 +80,9 @@ await myZapProvider.respond({queryId,responseParams,dynamic}); //string, array, 
 
 ### See more Usages of each packages :
 * [Subscriber](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Subscriber/README.md)
-* [Register](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Register/README.md)
+* [Registry](https://github.com/zapproject/zap-monorepo/blob/master/packages/Registry/README.md)
 * [Bondage](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Bondage/README.md)
 * [Dispatch](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Dispatch/README.md)
 * [Arbiter](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Arbiter/README.md)
 * [ZapToken](https://github.com/zapproject/Zap-monorepo/tree/master/packages/ZapToken/README.md)
 * [Zapjs](https://github.com/zapproject/Zap-monorepo/tree/master/packages/ZapJs/README.md)
-
-

--- a/packages/Subscriber/README.md
+++ b/packages/Subscriber/README.md
@@ -39,11 +39,9 @@ await myZapSubscriber.subscribe({provider, endpoint, endpointParams, dots})
 
 ### See more Usages of each packages :
 * [Provider](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Provider/README.md)
-* [Register](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Register/README.md)
+* [Registry](https://github.com/zapproject/zap-monorepo/blob/master/packages/Registry/README.md)
 * [Bondage](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Bondage/README.md)
 * [Dispatch](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Dispatch/README.md)
 * [Arbiter](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Arbiter/README.md)
 * [ZapToken](https://github.com/zapproject/Zap-monorepo/tree/master/packages/ZapToken/README.md)
 * [Zapjs](https://github.com/zapproject/Zap-monorepo/tree/master/packages/ZapJs/README.md)
-
-

--- a/packages/Types/README.md
+++ b/packages/Types/README.md
@@ -4,10 +4,8 @@ This repository provides an types that are shared in zapjs-monorepo packages
 ### See more Usages of each packages :
 * [Provider](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Provider/README.md)
 * [Subscriber](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Subscriber/README.md)
-* [Register](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Register/README.md)
+* [Registry](https://github.com/zapproject/zap-monorepo/blob/master/packages/Registry/README.md)
 * [Bondage](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Bondage/README.md)
 * [Dispatch](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Dispatch/README.md)
 * [Arbiter](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Arbiter/README.md)
 * [Zapjs](https://github.com/zapproject/Zap-monorepo/tree/master/packages/ZapJs/README.md)
-
-

--- a/packages/Utils/README.md
+++ b/packages/Utils/README.md
@@ -9,7 +9,7 @@ This repository provides utilities used in other @zapjs packages. This includes 
 - Typescript
 ```
 
-## Usage 
+## Usage
 ```
 npm install `@zapjs/utils`
 ```
@@ -26,14 +26,9 @@ Utils.normalizeProvider(ZapProvider)
 ### See more Usages of each packages :
 * [Provider](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Provider/README.md)
 * [Subscriber](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Subscriber/README.md)
-* [Register](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Register/README.md)
+* [Registry](https://github.com/zapproject/zap-monorepo/blob/master/packages/Registry/README.md)
 * [Bondage](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Bondage/README.md)
 * [Dispatch](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Dispatch/README.md)
 * [Arbiter](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Arbiter/README.md)
 * [ZapToken](https://github.com/zapproject/Zap-monorepo/tree/master/packages/ZapToken/README.md)
 * [Zapjs](https://github.com/zapproject/Zap-monorepo/tree/master/packages/ZapJs/README.md)
-
-
-
-
-

--- a/packages/ZapJs/README.md
+++ b/packages/ZapJs/README.md
@@ -16,18 +16,18 @@ npm install --save `zapjs`
 ```
 import {ZapArbiter,ZapProvider,ZapSubscriber,ZapToken} from 'zapjs';
 
-let myZapToken = new ZapToken(); 
+let myZapToken = new ZapToken();
 ```
 
 Custom configuration
-``` 
+```
 let myZapToken = new ZapToken({artifactDir,networkId,networkProvider})
 ```
 
 ### See more Usages of each packages :
 * [Provider](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Provider/README.md)
 * [Subscriber](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Subscriber/README.md)
-* [Register](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Register/README.md)
+* [Registry](https://github.com/zapproject/zap-monorepo/blob/master/packages/Registry/README.md)
 * [Bondage](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Bondage/README.md)
 * [Dispatch](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Dispatch/README.md)
 * [Arbiter](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Arbiter/README.md)
@@ -36,8 +36,7 @@ let myZapToken = new ZapToken({artifactDir,networkId,networkProvider})
 ## Built With
 
 * [Lerna](https://lernajs.io/) - The tool to manage monorepo project
-* [Typescript](https://www.typescriptlang.org/) 
-* [Mocha](https://mochajs.org/) 
+* [Typescript](https://www.typescriptlang.org/)
+* [Mocha](https://mochajs.org/)
 * [Truffle](https://truffleframework.com/)
 * [Ganache](https://truffleframework.com/ganache)
-

--- a/packages/ZapToken/README.md
+++ b/packages/ZapToken/README.md
@@ -16,11 +16,11 @@ npm install --save `@zapjs/zaptoken`
 ```
 import {ZaopToken} from '@zapjs/zaptoken';
 
-let myZapToken = new ZapToken(); 
+let myZapToken = new ZapToken();
 ```
 
 Custom configuration
-``` 
+```
 let myZapToken = new ZapToken({artifactDir,networkId,networkProvider})
 ```
 
@@ -42,7 +42,7 @@ await myZapToken.send({from,to,amount,gas})
 ### See more Usages of each packages :
 * [Provider](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Provider/README.md)
 * [Subscriber](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Subscriber/README.md)
-* [Register](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Register/README.md)
+* [Registry](https://github.com/zapproject/zap-monorepo/blob/master/packages/Registry/README.md)
 * [Bondage](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Bondage/README.md)
 * [Dispatch](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Dispatch/README.md)
 * [Arbiter](https://github.com/zapproject/Zap-monorepo/tree/master/packages/Arbiter/README.md)
@@ -53,8 +53,7 @@ await myZapToken.send({from,to,amount,gas})
 ## Built With
 
 * [Lerna](https://lernajs.io/) - The tool to manage monorepo project
-* [Typescript](https://www.typescriptlang.org/) 
-* [Mocha](https://mochajs.org/) 
+* [Typescript](https://www.typescriptlang.org/)
+* [Mocha](https://mochajs.org/)
 * [Truffle](https://truffleframework.com/)
 * [Ganache](https://truffleframework.com/ganache)
-


### PR DESCRIPTION
I noticed that the Register link at the bottom of each README.md appears to be broken. It points to:

    https://github.com/zapproject/Zap-monorepo/tree/master/packages/Register/README.md

When it should actually point to:

    https://github.com/zapproject/zap-monorepo/tree/master/packages/Registry/README.md

I have updated this in each README.md file where the Register link appeared.