### PR TITLE
Coordinator

### DIFF
--- a/packages/Artifacts/contracts/ZapCoordinator.json
+++ b/packages/Artifacts/contracts/ZapCoordinator.json
@@ -1,0 +1,216 @@
+{
+  "contractName": "ZapCoordinator",
+  "abi": [
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "db",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "loadedContracts",
+      "outputs": [
+        {
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "name": "previousAddr",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "newAddr",
+          "type": "address"
+        }
+      ],
+      "name": "UpdatedContract",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "name": "timestamp",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "name": "contractName",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "name": "contractAddr",
+          "type": "address"
+        }
+      ],
+      "name": "UpdatedDependencies",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "contractName",
+          "type": "string"
+        },
+        {
+          "name": "newAddress",
+          "type": "address"
+        }
+      ],
+      "name": "addImmutableContract",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "contractName",
+          "type": "string"
+        },
+        {
+          "name": "newAddress",
+          "type": "address"
+        }
+      ],
+      "name": "updateContract",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "index",
+          "type": "uint256"
+        }
+      ],
+      "name": "getContractName",
+      "outputs": [
+        {
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "contractName",
+          "type": "string"
+        }
+      ],
+      "name": "getContract",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [],
+      "name": "updateAllDependencies",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "networks": {
+    "42": {
+      "address": "0x0014f9acd4f4ad4ac65fec3dcee75736fd0a0230"
+    }
+  },
+  "schemaVersion": "2.0.1"
+}

--- a/packages/Artifacts/contracts/ZapCoordinatorInterface.json
+++ b/packages/Artifacts/contracts/ZapCoordinatorInterface.json
@@ -1,0 +1,133 @@
+{
+  "contractName": "ZapCoordinatorInterface",
+  "abi": [
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "contractName",
+          "type": "string"
+        },
+        {
+          "name": "newAddress",
+          "type": "address"
+        }
+      ],
+      "name": "addImmutableContract",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "contractName",
+          "type": "string"
+        },
+        {
+          "name": "newAddress",
+          "type": "address"
+        }
+      ],
+      "name": "updateContract",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "index",
+          "type": "uint256"
+        }
+      ],
+      "name": "getContractName",
+      "outputs": [
+        {
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "contractName",
+          "type": "string"
+        }
+      ],
+      "name": "getContract",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [],
+      "name": "updateAllDependencies",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ]
+}

--- a/packages/Artifacts/src/index.ts
+++ b/packages/Artifacts/src/index.ts
@@ -1,8 +1,8 @@
 export const Artifacts :{[index:string]:any} =  {
-    "Arbiter" : require("../contracts/Arbiter.json"),
-    "Bondage" : require("../contracts/Bondage.json"),
-    "Dispatch" : require("../contracts/Dispatch.json"),
-    "Registry" : require("../contracts/Registry.json"),
+    "ARBITER" : require("../contracts/Arbiter.json"),
+    "BONDAGE" : require("../contracts/Bondage.json"),
+    "DISPATCH" : require("../contracts/Dispatch.json"),
+    "REGISTRY" : require("../contracts/Registry.json"),
     "CurrentCost" : require("../contracts/CurrentCost.json"),
     "PiecewiseLogic" : require("../contracts/PiecewiseLogic.json"),
     "ZAP_TOKEN" : require("../contracts/ZapToken.json"),
@@ -10,7 +10,7 @@ export const Artifacts :{[index:string]:any} =  {
     "Client2" : require("../contracts/Client2.json"),
     "Client3" : require("../contracts/Client3.json"),
     "Client4" : require("../contracts/Client4.json"),
-    "ZapCoordinator": require("../contracts/ZapCoordinator.json")
+    "ZAPCOORDINATOR": require("../contracts/ZapCoordinator.json")
 }
 
 

--- a/packages/Artifacts/src/index.ts
+++ b/packages/Artifacts/src/index.ts
@@ -5,11 +5,12 @@ export const Artifacts :{[index:string]:any} =  {
     "Registry" : require("../contracts/Registry.json"),
     "CurrentCost" : require("../contracts/CurrentCost.json"),
     "PiecewiseLogic" : require("../contracts/PiecewiseLogic.json"),
-    "ZapToken" : require("../contracts/ZapToken.json"),
+    "ZAP_TOKEN" : require("../contracts/ZapToken.json"),
     "Client1" : require("../contracts/Client1.json"),
     "Client2" : require("../contracts/Client2.json"),
     "Client3" : require("../contracts/Client3.json"),
-    "Client4" : require("../contracts/Client4.json")
+    "Client4" : require("../contracts/Client4.json"),
+    "ZapCoordinator": require("../contracts/ZapCoordinator.json")
 }
 
 

--- a/packages/BaseContract/src/index.ts
+++ b/packages/BaseContract/src/index.ts
@@ -35,12 +35,12 @@ export class BaseContract{
         try {
           if(!artifactsDir){
             this.artifact = Artifacts[artifactName];
-            coorArtifact = Artifacts['ZapCoordinator']
+            coorArtifact = Artifacts['ZAPCOORDINATOR']
           }
           else{
             let artifacts:any= Utils.getArtifacts(artifactsDir);
             this.artifact = artifacts[artifactName];
-            coorArtifact = artifacts['ZapCoordinator']
+            coorArtifact = artifacts['ZAPCOORDINATOR']
           }
           let currentProvider = networkProvider || new Web3.providers.HttpProvider("http://localhost:8545");
           this.provider = new Web3(currentProvider)
@@ -51,10 +51,14 @@ export class BaseContract{
           }
           this.coordinator = new this.provider.eth.Contract(coorArtifact.abi,coordinator||coorArtifact.networks[this.networkId].address);
           this.contract = undefined;
-          this.getContract()
-              .then(console.log)
-              .catch(console.error)
-        //  this.contract = new this.provider.eth.Contract(this.artifact.abi,this.artifact.networks[this.networkId].address)
+          if(coordinator) {
+              this.getContract()
+                  .then(console.log)
+                  .catch(console.error)
+          }
+          else {
+              this.contract = new this.provider.eth.Contract(this.artifact.abi,this.artifact.networks[this.networkId].address)
+          }
         } catch (err) {
             throw err;
         }

--- a/packages/BaseContract/src/index.ts
+++ b/packages/BaseContract/src/index.ts
@@ -2,7 +2,7 @@ import  {Artifacts} from "@zapjs/artifacts";
 import {BaseContractType} from "@zapjs/types";
 import {Utils} from "./utils"
 const Web3 = require("web3")
-const CONTRACTS = ['ZAP_TOKEN','DISPATCH','ARBITER','BONDAGE','REGISTRY','DATABASE']
+const CONTRACTS = ['ZAP_TOKEN','DISPATCH','ARBITER','BONDAGE','REGISTRY','DATABASE','ZAPCOORDINATOR']
 
 /**
  * Parent Class to Dispatch, Bondage, Arbiter, Token, Registry classes
@@ -46,22 +46,24 @@ export class BaseContract{
           this.provider = new Web3(currentProvider)
             //network id default to mainnet
           this.networkId = networkId || 1;
-          this.coordinator = new this.provider.eth.Contract(coorArtifact.abi,coordinator||coorArtifact[this.networkId].address);
+          if(coordinator){
+              console.log("GETTING CONTRACT FROM COORDINATOR")
+          }
+          this.coordinator = new this.provider.eth.Contract(coorArtifact.abi,coordinator||coorArtifact.networks[this.networkId].address);
           this.contract = undefined;
           this.getContract()
-            .catch(e=>{
-              throw "Cant get contract : "+e
-            })
-          // this.contract = new this.provider.eth.Contract(artifact.abi,artifact.networks[this.networkId].address)
+              .then(console.log)
+              .catch(console.error)
+        //  this.contract = new this.provider.eth.Contract(this.artifact.abi,this.artifact.networks[this.networkId].address)
         } catch (err) {
             throw err;
         }
     }
 
-    async getContract(){
-      let contractAddress = await this.coordinator.methods.getcontract(this.name.toUpperCase()).call().valueOf();
+     async getContract(){
+      let contractAddress = await this.coordinator.methods.getContract(this.name.toUpperCase()).call().valueOf();
       this.contract = new this.provider.eth.Contract(this.artifact.abi,contractAddress)
-
+      return contractAddress
     }
 
     /**

--- a/packages/BaseContract/src/index.ts
+++ b/packages/BaseContract/src/index.ts
@@ -2,6 +2,7 @@ import  {Artifacts} from "@zapjs/artifacts";
 import {BaseContractType} from "@zapjs/types";
 import {Utils} from "./utils"
 const Web3 = require("web3")
+const CONTRACTS = ['ZAP_TOKEN','DISPATCH','ARBITER','BONDAGE','REGISTRY','DATABASE']
 
 /**
  * Parent Class to Dispatch, Bondage, Arbiter, Token, Registry classes
@@ -12,6 +13,9 @@ export class BaseContract{
     web3:any;
     contract:any;
     networkId:number;
+    coordinator:any;
+    artifact:any;
+    name:string;
 
     /**
      * Creates a contract class wrapper for a given contract.
@@ -22,25 +26,42 @@ export class BaseContract{
      * @param {number | null} b.networkId - Select which network the contract is located on (mainnet, testnet, private)
      * @param {any | null} b.networkProvider - Ethereum network provider (e.g. Infura)
      */
-    constructor({artifactsDir,artifactName,networkId,networkProvider}:BaseContractType) {
-        let artifact:any = undefined;
+    constructor({artifactsDir,artifactName,networkId,networkProvider,coordinator}:BaseContractType) {
+        let coorArtifact:any=undefined;
+        this.name = artifactName;
+        if(!CONTRACTS.includes(artifactName.toUpperCase())){
+          throw "Contract name is invalid";
+        }
         try {
           if(!artifactsDir){
-            artifact = Artifacts[artifactName];
+            this.artifact = Artifacts[artifactName];
+            coorArtifact = Artifacts['ZapCoordinator']
           }
           else{
             let artifacts:any= Utils.getArtifacts(artifactsDir);
-            artifact = artifacts[artifactName];
+            this.artifact = artifacts[artifactName];
+            coorArtifact = artifacts['ZapCoordinator']
           }
           let currentProvider = networkProvider || new Web3.providers.HttpProvider("http://localhost:8545");
           this.provider = new Web3(currentProvider)
             //network id default to mainnet
           this.networkId = networkId || 1;
-          //console.log("Initialize contract: ",artifactName, artifactsDir, this.networkId, artifact.networks)
-          this.contract = new this.provider.eth.Contract(artifact.abi,artifact.networks[this.networkId].address)
+          this.coordinator = new this.provider.eth.Contract(coorArtifact.abi,coordinator||coorArtifact[this.networkId].address);
+          this.contract = undefined;
+          this.getContract()
+            .catch(e=>{
+              throw "Cant get contract : "+e
+            })
+          // this.contract = new this.provider.eth.Contract(artifact.abi,artifact.networks[this.networkId].address)
         } catch (err) {
             throw err;
         }
+    }
+
+    async getContract(){
+      let contractAddress = await this.coordinator.methods.getcontract(this.name.toUpperCase()).call().valueOf();
+      this.contract = new this.provider.eth.Contract(this.artifact.abi,contractAddress)
+
     }
 
     /**

--- a/packages/BaseContract/src/utils.ts
+++ b/packages/BaseContract/src/utils.ts
@@ -8,10 +8,10 @@ export class Utils {
     static getArtifacts(buildDir: string) {
         let artifacts: any = {};
         artifacts = {
-            Arbiter: require(join(buildDir, "Arbiter.json")),
-            Bondage: require(join(buildDir,"Bondage.json")),
-            Dispatch: require(join(buildDir,"Dispatch.json")),
-            Registry: require(join(buildDir,"Registry.json")),
+            ARBITER: require(join(buildDir, "Arbiter.json")),
+            BONDAGE: require(join(buildDir,"Bondage.json")),
+            DISPATCH: require(join(buildDir,"Dispatch.json")),
+            REGISTRY: require(join(buildDir,"Registry.json")),
             CurrentCost: require(join(buildDir,"CurrentCost.json")),
             PiecewiseLogic: require(join(buildDir,"PiecewiseLogic.json")),
             ZAP_TOKEN: require(join(buildDir,"ZapToken.json")),
@@ -19,7 +19,7 @@ export class Utils {
             Client2: require(join(buildDir,"Client2.json")),
             Client3: require(join(buildDir,"Client3.json")),
             Client4: require(join(buildDir,"Client4.json")),
-            ZapCoordinator: require(join(buildDir,"ZapCoordinator.json"))
+            ZAPCOORDINATOR: require(join(buildDir,"ZapCoordinator.json"))
         }
         return artifacts
 

--- a/packages/BaseContract/src/utils.ts
+++ b/packages/BaseContract/src/utils.ts
@@ -14,11 +14,12 @@ export class Utils {
             Registry: require(join(buildDir,"Registry.json")),
             CurrentCost: require(join(buildDir,"CurrentCost.json")),
             PiecewiseLogic: require(join(buildDir,"PiecewiseLogic.json")),
-            ZapToken: require(join(buildDir,"ZapToken.json")),
+            ZAP_TOKEN: require(join(buildDir,"ZapToken.json")),
             Client1: require(join(buildDir,"Client1.json")),
             Client2: require(join(buildDir,"Client2.json")),
             Client3: require(join(buildDir,"Client3.json")),
             Client4: require(join(buildDir,"Client4.json")),
+            ZapCoordinator: require(join(buildDir,"ZapCoordinator.json"))
         }
         return artifacts
 

--- a/packages/Bondage/src/index.ts
+++ b/packages/Bondage/src/index.ts
@@ -20,7 +20,7 @@ export class ZapBondage extends BaseContract {
      * @example new ZaBondage({networkId : 42, networkProvider : web3})
      */
     constructor(obj ?: NetworkProviderOptions){
-        super(Object.assign(obj,{artifactName:"Bondage"}));
+        super(Object.assign(obj,{artifactName:"BONDAGE"}));
     }
 
     /**

--- a/packages/Bondage/test/zapBondageTest.ts
+++ b/packages/Bondage/test/zapBondageTest.ts
@@ -47,9 +47,10 @@ describe('Zap Bondage Test', () => {
             // delete require.cache[require.resolve('/contracts')];
             await Utils.migrateContracts(buildDir);
             testArtifacts = Utils.getArtifacts(buildDir);
-            deployedBondage = new BaseContract(Object.assign(options, {artifactName: "Bondage"}));
-            deployedRegistry = new BaseContract(Object.assign(options, {artifactName: "Registry"}));
-            deployedToken = new BaseContract(Object.assign(options, {artifactName: "ZapToken"}));
+            deployedBondage = new BaseContract(Object.assign(options, {artifactName: "BONDAGE"}));
+            deployedRegistry = new BaseContract(Object.assign(options, {artifactName: "REGISTRY"}));
+            deployedToken = new BaseContract(Object.assign(options, {artifactName: "ZAP_TOKEN"}));
+            await Utils.delay(3000)
             done();
         });
     });
@@ -65,7 +66,17 @@ describe('Zap Bondage Test', () => {
         });
     it("2) Should initiate Bondage Wrapper", async () => {
             bondageWrapper = new ZapBondage(options);
-        });
+            await Utils.delay(3000)
+            expect(bondageWrapper).to.be.ok
+
+    });
+    it("2) Should initiate Bondage Wrapper through coordinator address", async () => {
+        options.coordinator = bondageWrapper.coordinator._address
+        bondageWrapper = new ZapBondage(options);
+        await Utils.delay(3000);
+        expect(bondageWrapper).to.be.ok
+    });
+
     it("3) Should have no bound dots for new provider", async () => {
             const boundDots = await bondageWrapper.getBoundDots({subscriber: accounts[2], provider: accounts[0], endpoint: testZapProvider.endpoint});
             expect(boundDots).to.equal('0');

--- a/packages/Dispatch/src/index.ts
+++ b/packages/Dispatch/src/index.ts
@@ -15,7 +15,7 @@ export class ZapDispatch extends BaseContract {
      * @example new ZapDispatch({networkId : 42, networkProvider : web3})
      */
     constructor(obj ?: NetworkProviderOptions){
-        super(Object.assign(obj, {artifactName:"Dispatch"}));
+        super(Object.assign(obj, {artifactName:"DISPATCH"}));
     }
 
    /**

--- a/packages/Dispatch/test/utils/setup_test.ts
+++ b/packages/Dispatch/test/utils/setup_test.ts
@@ -1,7 +1,6 @@
 const Web3 = require('web3');
 import {Utils} from "@zapjs/utils";
 import {NULL_ADDRESS} from  "@zapjs/types"
-
 /**
  * Bootstrap for Dispatch tests, with accounts[0] = provider, accounts[2]=subscriber
  * @param {} zapProvider

--- a/packages/Dispatch/test/zapDispatchTest.ts
+++ b/packages/Dispatch/test/zapDispatchTest.ts
@@ -15,7 +15,6 @@ async function configureEnvironment(func:Function) {
     await func();
 }
 
-const delay = (ms:number) => new Promise(_ => setTimeout(_, ms));
 
 
 describe('Zap Dispatch Test', () => {
@@ -47,10 +46,10 @@ describe('Zap Dispatch Test', () => {
             await Utils.migrateContracts(buildDir);
             console.log("Migration complete. ");
             testArtifacts = Utils.getArtifacts(buildDir);
-            deployedBondage = new BaseContract(Object.assign(options, {artifactName: "Bondage"}));
-            deployedRegistry = new BaseContract(Object.assign(options, {artifactName: "Registry"}));
+            deployedBondage = new BaseContract(Object.assign(options, {artifactName: "BONDAGE"}));
+            deployedRegistry = new BaseContract(Object.assign(options, {artifactName: "REGISTRY"}));
             deployedToken = new BaseContract(Object.assign(options, {artifactName: "ZAP_TOKEN"}));
-            await delay(3000)
+            await Utils.delay(3000)
             done();
         });
     });
@@ -68,15 +67,14 @@ describe('Zap Dispatch Test', () => {
 
     it("Should initiate Dispatch Wrapper", async () => {
         dispatchWrapper = new ZapDispatch(options);
-        await delay(3000)
+        await Utils.delay(3000)
         expect(dispatchWrapper).to.be.ok;
     });
 
     it("Should initiate Dispatch Wrapper with coordinator address", async () => {
         options.coordinator = dispatchWrapper.coordinator._address;
-        console.log("coordinator address", options.coordinator)
         dispatchWrapper = new ZapDispatch(options);
-        await delay(3000)
+        await Utils.delay(3000)
         expect(dispatchWrapper).to.be.ok;
     });
 

--- a/packages/Dispatch/test/zapDispatchTest.ts
+++ b/packages/Dispatch/test/zapDispatchTest.ts
@@ -15,6 +15,9 @@ async function configureEnvironment(func:Function) {
     await func();
 }
 
+const delay = (ms:number) => new Promise(_ => setTimeout(_, ms));
+
+
 describe('Zap Dispatch Test', () => {
     let accounts :Array<string>= [],
     ganacheServer:any,
@@ -22,6 +25,7 @@ describe('Zap Dispatch Test', () => {
     deployedRegistry:any,
     deployedToken:any,
     deployedBondage:any,
+    coordinator:any,
     web3:any,
     testArtifacts,
     query="TestQuery",
@@ -45,7 +49,8 @@ describe('Zap Dispatch Test', () => {
             testArtifacts = Utils.getArtifacts(buildDir);
             deployedBondage = new BaseContract(Object.assign(options, {artifactName: "Bondage"}));
             deployedRegistry = new BaseContract(Object.assign(options, {artifactName: "Registry"}));
-            deployedToken = new BaseContract(Object.assign(options, {artifactName: "ZapToken"}));
+            deployedToken = new BaseContract(Object.assign(options, {artifactName: "ZAP_TOKEN"}));
+            await delay(3000)
             done();
         });
     });
@@ -61,10 +66,19 @@ describe('Zap Dispatch Test', () => {
      await expect(res).to.be.equal("done");
     });
 
-        it("Should initiate Dispatch Wrapper", async () => {
-            dispatchWrapper = new ZapDispatch(options);
-            expect(dispatchWrapper).to.be.ok;
-        });
+    it("Should initiate Dispatch Wrapper", async () => {
+        dispatchWrapper = new ZapDispatch(options);
+        await delay(3000)
+        expect(dispatchWrapper).to.be.ok;
+    });
+
+    it("Should initiate Dispatch Wrapper with coordinator address", async () => {
+        options.coordinator = dispatchWrapper.coordinator._address;
+        console.log("coordinator address", options.coordinator)
+        dispatchWrapper = new ZapDispatch(options);
+        await delay(3000)
+        expect(dispatchWrapper).to.be.ok;
+    });
 
     it("Should call query function in Dispatch smart contract", async () => {
         queryData = await dispatchWrapper.queryData({

--- a/packages/Registry/src/index.ts
+++ b/packages/Registry/src/index.ts
@@ -17,7 +17,7 @@ import {Filter, txid,address,NetworkProviderOptions,DEFAULT_GAS,NULL_ADDRESS} fr
      * @example new ZapRegistry({networkId : 42, networkProvider : web3})
      */
     constructor(obj ?: NetworkProviderOptions){
-        super(Object.assign(obj,{artifactName:"Registry"}));
+        super(Object.assign(obj,{artifactName:"REGISTRY"}));
     }
 
 

--- a/packages/Registry/src/index.ts
+++ b/packages/Registry/src/index.ts
@@ -101,7 +101,7 @@ import {Filter, txid,address,NetworkProviderOptions,DEFAULT_GAS,NULL_ADDRESS} fr
      * @returns {Promise<string>} Returns a Promise that will eventually resolve into public key number
      */
     async getEndpointBroker(provider:address, endpoint:string ):Promise<string>{
-        let broker =  await this.contract.methods.getEndpointBroker(provider, endpoint).call();
+        let broker =  await this.contract.methods.getEndpointBroker(provider, utf8ToHex(endpoint)).call();
         return hexToUtf8(broker);
     }
 
@@ -132,7 +132,7 @@ import {Filter, txid,address,NetworkProviderOptions,DEFAULT_GAS,NULL_ADDRESS} fr
      * @returns {Promise<boolean>} Returns a Promise that will eventually resolve a true/false value.
      */
     async isEndpointSet(provider:address, endpoint:string):Promise<boolean> {
-        const unset:boolean = await this.contract.methods.getCurveUnset(provider, endpoint).call();
+        const unset:boolean = await this.contract.methods.getCurveUnset(provider, utf8ToHex(endpoint)).call();
         return !unset;
     }
 

--- a/packages/Registry/test/zapRegistryTest.ts
+++ b/packages/Registry/test/zapRegistryTest.ts
@@ -22,7 +22,7 @@ describe('Registry test', () => {
     testArtifacts,
     testZapProvider = Utils.Constants.testZapProvider,
     buildDir:string = join(__dirname,"contracts"),
-    options = {
+    options:any = {
         artifactsDir: buildDir,
         networkId: Utils.Constants.ganacheServerOptions.network_id,
         networkProvider: Utils.Constants.ganacheProvider
@@ -36,6 +36,7 @@ describe('Registry test', () => {
             //delete require.cache[require.resolve('/contracts')];
             await Utils.migrateContracts(join(__dirname,"contracts"));
             testArtifacts = Utils.getArtifacts(join(__dirname,"contracts"));
+            await Utils.delay(3000)
             done();
         });
     });
@@ -48,7 +49,16 @@ describe('Registry test', () => {
 
     it("should be able to create registryWrapper", async ()=>{
         registryWrapper = new ZapRegistry(options)
-    })
+        await Utils.delay(3000);
+        expect(registryWrapper).to.be.ok
+    });
+
+    it("should be able to create registryWrapper with coordinator", async ()=>{
+        options.coordinator = registryWrapper.coordinator._address
+        registryWrapper = new ZapRegistry(options)
+        await Utils.delay(3000);
+        expect(registryWrapper).to.be.ok
+    });
 
 
     it('Should initiate provider in zap registry contract', async () => {

--- a/packages/Types/src/index.ts
+++ b/packages/Types/src/index.ts
@@ -66,10 +66,11 @@ export interface BaseContractType  {
     contract ?: any,
     coordinator ?:string
 }
-export interface NetworkProviderOptions {
+export interface NetworkProviderOptions{
     artifactsDir ?:string|undefined,
     networkId?: number|undefined,
-    networkProvider: any
+    networkProvider: any,
+    coordinator ?:string
 }
 
 export interface TransferType extends defaultTx{

--- a/packages/Types/src/index.ts
+++ b/packages/Types/src/index.ts
@@ -63,7 +63,8 @@ export interface BaseContractType  {
     artifactName: string,
     networkId?: number|undefined,
     networkProvider?: any|undefined,
-    contract ?: any
+    contract ?: any,
+    coordinator ?:string
 }
 export interface NetworkProviderOptions {
     artifactsDir ?:string|undefined,

--- a/packages/Utils/src/index.ts
+++ b/packages/Utils/src/index.ts
@@ -54,6 +54,13 @@ export class Utils {
     };
 
     /**
+     * Delay async
+     * @param ms
+     */
+    static delay = (ms:number) => new Promise(_ => setTimeout(_, ms));
+
+
+    /**
      * @param {number} num
      * @returns {any}
      */

--- a/packages/ZapToken/src/index.ts
+++ b/packages/ZapToken/src/index.ts
@@ -20,7 +20,7 @@ import {TransferType,address,txid,NetworkProviderOptions,BNType} from "@zapjs/ty
       */
 
     constructor(obj ?: NetworkProviderOptions){
-        super(Object.assign(obj,{artifactName:"ZapToken"}));
+        super(Object.assign(obj,{artifactName:"ZAP_TOKEN"}));
     }
 
 

--- a/packages/ZapToken/test/zapTokenTest.ts
+++ b/packages/ZapToken/test/zapTokenTest.ts
@@ -48,15 +48,21 @@ describe('ZapToken, path to "/src/api/contracts/ZapToken"', () => {
             artifactsDir : buildDir,
             networkId: Utils.Constants.ganacheServerOptions.network_id,
             networkProvider: Utils.Constants.ganacheProvider});
+        await Utils.delay(3000)
+        expect(zapTokenWrapper).to.be.ok
         zapTokenOwner = await  zapTokenWrapper.getContractOwner()
     });
 
 
-    it('Should initiate wrapper', async () => {
+    it('Should initiate wrapper with coordinator ', async () => {
         zapTokenWrapper = new ZapToken({
             artifactsDir : buildDir,
             networkId: Utils.Constants.ganacheServerOptions.network_id,
-            networkProvider: Utils.Constants.ganacheProvider});
+            networkProvider: Utils.Constants.ganacheProvider,
+            coordinator:zapTokenWrapper.coordinator._address
+        });
+        await Utils.delay(3000)
+        expect(zapTokenWrapper).to.be.ok
         zapTokenOwner = await  zapTokenWrapper.getContractOwner()
     });
 


### PR DESCRIPTION
- Allow option to use coordinator address to get other contracts
- In this case, there should be a sleep time after initiating object to allow basecontract to get address from the network.
- Backward compatible