### PR TITLE
Chunk encoding for endpoint params in registry monorepo package

### DIFF
--- a/packages/Provider/src/index.ts
+++ b/packages/Provider/src/index.ts
@@ -220,7 +220,7 @@ import {ZapArbiter} from "@zapjs/arbiter";
      * @param {string} endpoint - Endpoint identifier
      * @returns {Promise<string>} Returns a Promise that will eventually resolve into the endpoint's param at this index
      */
-    async getEndpointParams(endpoint: string):Promise<string>{
+    async getEndpointParams(endpoint: string):Promise<string[]>{
         return await this.zapRegistry.getEndpointParams({ provider: this.providerOwner, endpoint });
     }
 

--- a/packages/Registry/test/zapRegistryTest.ts
+++ b/packages/Registry/test/zapRegistryTest.ts
@@ -143,6 +143,24 @@ describe('Registry test', () => {
         });
 
     });
+    it('Should set endpoint endpointParams in chunks in zap registry contract', async () => {
+        let result = await registryWrapper.setEndpointParams({
+            endpoint: testZapProvider.endpoint,
+            endpoint_params: ["http://test_url_that_is_longer_than_32_bytes_oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.com"],
+            from: accounts[0],
+            gas: 600000
+        });
+    });
+    it('Should get endpoint endpointParams in chunks in zap registry contract', async () => {
+        let result = await registryWrapper.getEndpointParams({
+            provider:accounts[0],
+            endpoint: testZapProvider.endpoint});
+        expect(result).to.be.ok
+        expect(result.length).to.be.equal(1)
+        expect(result[0]).to.equal("http://test_url_that_is_longer_than_32_bytes_oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.com")
+    });
+
+
 
     after(function () {
         ganacheServer.close();


### PR DESCRIPTION
Augment getEndpointParams setEndpointParams in registry package to allow for flexible length parameters that may expand across bytes32 elements in the actual contract storage.
