### PR TITLE
added hardhat network id

### DIFF
--- a/packages/Artifacts/contracts/Arbiter.json
+++ b/packages/Artifacts/contracts/Arbiter.json
@@ -417,6 +417,9 @@
       "links": {},
       "address": "0x070292738be65239c28a1fbdb51ef61b8b37cd83",
       "transactionHash": "0xd891f92a9be7d2cb45ff46bbdfdf1cf20cc9957a7f3137905e105abf24e01bc1"
+    },
+    "31337": {
+      "address": "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9"
     }
   }
 }

--- a/packages/Artifacts/contracts/Bondage.json
+++ b/packages/Artifacts/contracts/Bondage.json
@@ -747,6 +747,9 @@
       "links": {},
       "address": "0x1e918abeb37d45aed177e1821dd6a3ab14415ce3",
       "transactionHash": "0xbf5c11d55267fc39e8d3c7cb1b8aac179c2141ec7dd26a98d03017cd4676b79e"
+    },
+    "31337": {
+      "address": "0x5FC8d32690cc91D4c39d9d3abcBD16989F875707"
     }
   }
 }

--- a/packages/Artifacts/contracts/Dispatch.json
+++ b/packages/Artifacts/contracts/Dispatch.json
@@ -769,6 +769,8 @@
       "links": {},
       "address": "0x6b7e01d804e68143b8c3e4c54f81daea3fd0189a",
       "transactionHash": "0x9cbc488a7a4f2a217261e5f456f0118386a0a4b689e6c8ba8c601bda9341dd64"
+    },
+    "31337": {
+      "address": "0x0165878A594ca255338adfa4d48449f69242Eb8F"
     }
-  }
 }

--- a/packages/Artifacts/contracts/Registry.json
+++ b/packages/Artifacts/contracts/Registry.json
@@ -563,6 +563,9 @@
       "links": {},
       "address": "0x513846a568407ebd16bc29d238c364702963377d",
       "transactionHash": "0x9e913c416007746fb8967fb52558117ec97fd174b9f5368af08c7b951ccbb54e"
+    },
+    "31337": {
+      "address": "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853"
     }
   }
 }

--- a/packages/Artifacts/contracts/ZapCoordinator.json
+++ b/packages/Artifacts/contracts/ZapCoordinator.json
@@ -213,6 +213,9 @@
     },
     "42": {
       "address": "0xdbcac7c8bcca78fb05e96d0d2c68efb1c5922539"
+    },
+    "31337": {
+      "address": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0"
     }
   }
 }


### PR DESCRIPTION
##  Implementation

The Hardhat development enviroment uses network ID # 31337 (nice). I added it to the all the artifacts neccessary!

## Files

``` 
        modified:   packages/Artifacts/contracts/Arbiter.json
        modified:   packages/Artifacts/contracts/Bondage.json
        modified:   packages/Artifacts/contracts/Dispatch.json
        modified:   packages/Artifacts/contracts/Registry.json
        modified:   packages/Artifacts/contracts/ZapCoordinator.json
```

Please contact me asap !